### PR TITLE
ログイン関連のリダイレクトなど

### DIFF
--- a/app/src/pages/Signin.vue
+++ b/app/src/pages/Signin.vue
@@ -50,8 +50,11 @@ export default {
       isProcessing: false
     }
   },
-  created () {
-    this.$store.dispatch('getLoginState')
+  async created () {
+    await this.$store.dispatch('getLoginState')
+    if (this.isLoggedIn) {
+      this.$router.replace('/timeline')
+    }
   },
   computed: {
     isLoggedIn () {

--- a/app/src/pages/Signup.vue
+++ b/app/src/pages/Signup.vue
@@ -71,8 +71,11 @@ export default {
     'common-header': Header,
     'v-icon': Icon
   },
-  created () {
-    this.$store.dispatch('getLoginState')
+  async created () {
+    await this.$store.dispatch('getLoginState')
+    if (this.isLoggedIn) {
+      this.$router.replace('/timeline')
+    }
   },
   computed: {
     isLoggedIn () {

--- a/app/src/router.js
+++ b/app/src/router.js
@@ -18,6 +18,10 @@ const router = new VueRouter({
       redirect: '/signin'
     },
     {
+      path: '/timeline',
+      redirect: '/timeline/tsurai'
+    },
+    {
       path: '/timeline/:mode',
       name: 'Timeline',
       component: Home

--- a/app/src/store/index.js
+++ b/app/src/store/index.js
@@ -194,21 +194,35 @@ export default new Vuex.Store({
       }
     },
     async getLoginState () {
-      firebase.auth().onAuthStateChanged(user => {
-        this.commit('setLoginState', {loginState: !!user})
+      await new Promise((resolve) => {
+        let unsubscribe = firebase.auth().onAuthStateChanged(user => {
+          this.commit('setLoginState', {loginState: !!user})
+          unsubscribe()
+          resolve()
+        })
       })
     },
     async getUserInfoState () {
-      firebase.auth().onAuthStateChanged(async (user) => {
-        if (user) {
-          const userData = await getUser(user.uid)
-          this.commit('setUserInfoState', {data: userData})
-        }
+      await new Promise((resolve) => {
+        let unsubscribe = firebase.auth().onAuthStateChanged(async user => {
+          if (user) {
+            const userData = await getUser(user.uid)
+            this.commit('setUserInfoState', {data: userData})
+          }
+          unsubscribe()
+          resolve()
+        })
       })
     },
     async getVisitedUserInfoState (state, userAuthId) {
-      const visitedUserData = await getUser(userAuthId)
-      this.commit('setVisitedUserInfoState', {data: visitedUserData})
+      await new Promise((resolve) => {
+        let unsubscribe = firebase.auth().onAuthStateChanged(async user => {
+          const visitedUserData = await getUser(userAuthId)
+          this.commit('setVisitedUserInfoState', {data: visitedUserData})
+          unsubscribe()
+          resolve()
+        })
+      })
     }
   }
 })


### PR DESCRIPTION
/signin , /signup はログインしている場合/timelineにリダイレクト
/timeline をログインページではなくつらいTLにリダイレクト
storeのonAuthStateChanged絡みのActionを結果が反映されるまでawaitできるように。

Issue : #66